### PR TITLE
fix: add last note and local/remote fullnames in response

### DIFF
--- a/src/modules/appointment/appointment.controller.ts
+++ b/src/modules/appointment/appointment.controller.ts
@@ -46,7 +46,7 @@ export default class AppointmentController {
     @Param('id') id: number,
     @Query('limit') limit = TEN,
     @Param('all') all = false,
-  ): Promise<Appointment[]> {
+  ): Promise<{ appointments: Appointment[]; count: number }> {
     return this.appointmentService.getAppointmentsByDoctorIdToday(
       id,
       limit,

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -74,7 +74,11 @@ export default class AppointmentService {
         'remoteDoctor',
       );
       queryBuilder.leftJoinAndSelect('appointment.patient', 'patient');
-      queryBuilder.leftJoinAndSelect('patient.notes', 'notes');
+      queryBuilder.leftJoinAndSelect(
+        'patient.notes',
+        'notes',
+        'notes.createdAt = (SELECT MAX(n.createdAt) FROM note n WHERE n.patientId = patient.id)',
+      );
       queryBuilder.select([
         'appointment',
         'localDoctor.id',
@@ -88,18 +92,6 @@ export default class AppointmentService {
       ]);
 
       const appointments: Appointment[] = await queryBuilder.getMany();
-
-      for (let i = ZERO; i < appointments.length; i += ONE) {
-        const { patient, ...appointment } = appointments[i];
-        const lastNote = patient.notes.shift();
-        appointments[i] = {
-          ...appointment,
-          patient: {
-            ...patient,
-            notes: lastNote ? [lastNote] : [],
-          },
-        };
-      }
 
       return appointments;
     } catch (err) {
@@ -133,7 +125,11 @@ export default class AppointmentService {
         'remoteDoctor',
       );
       queryBuilder.leftJoinAndSelect('appointment.patient', 'patient');
-      queryBuilder.leftJoinAndSelect('patient.notes', 'notes');
+      queryBuilder.leftJoinAndSelect(
+        'patient.notes',
+        'notes',
+        'notes.createdAt = (SELECT MAX(n.createdAt) FROM note n WHERE n.patientId = patient.id)',
+      );
       queryBuilder.select([
         'appointment',
         'localDoctor.id',
@@ -151,18 +147,6 @@ export default class AppointmentService {
       }
 
       const appointments: Appointment[] = await queryBuilder.getMany();
-
-      for (let i = ZERO; i < appointments.length; i += ONE) {
-        const { patient, ...appointment } = appointments[i];
-        const lastNote = patient.notes.shift();
-        appointments[i] = {
-          ...appointment,
-          patient: {
-            ...patient,
-            notes: lastNote ? [lastNote] : [],
-          },
-        };
-      }
 
       return appointments;
     } catch (err) {
@@ -196,7 +180,11 @@ export default class AppointmentService {
         'remoteDoctor',
       );
       queryBuilder.leftJoinAndSelect('appointment.patient', 'patient');
-      queryBuilder.leftJoinAndSelect('patient.notes', 'notes');
+      queryBuilder.leftJoinAndSelect(
+        'patient.notes',
+        'notes',
+        'notes.createdAt = (SELECT MAX(n.createdAt) FROM note n WHERE n.patientId = patient.id)',
+      );
       queryBuilder.select([
         'appointment',
         'localDoctor.id',
@@ -210,18 +198,6 @@ export default class AppointmentService {
       ]);
 
       const appointments: Appointment[] = await queryBuilder.getMany();
-
-      for (let i = ZERO; i < appointments.length; i += ONE) {
-        const { patient, ...appointment } = appointments[i];
-        const lastNote = patient.notes.shift();
-        appointments[i] = {
-          ...appointment,
-          patient: {
-            ...patient,
-            notes: lastNote ? [lastNote] : [],
-          },
-        };
-      }
 
       return appointments;
     } catch (err) {

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -87,18 +87,19 @@ export default class AppointmentService {
         'notes',
       ]);
 
-      let appointments: Appointment[] = await queryBuilder.getMany();
+      const appointments: Appointment[] = await queryBuilder.getMany();
 
-      appointments = appointments.map(({ patient, ...appointment }) => {
+      for (let i = ZERO; i < appointments.length; i += ONE) {
+        const { patient, ...appointment } = appointments[i];
         const lastNote = patient.notes.shift();
-        return {
+        appointments[i] = {
           ...appointment,
           patient: {
             ...patient,
             notes: lastNote ? [lastNote] : [],
           },
         };
-      });
+      }
 
       return appointments;
     } catch (err) {
@@ -149,18 +150,19 @@ export default class AppointmentService {
         queryBuilder.limit(limit);
       }
 
-      let appointments: Appointment[] = await queryBuilder.getMany();
+      const appointments: Appointment[] = await queryBuilder.getMany();
 
-      appointments = appointments.map(({ patient, ...appointment }) => {
+      for (let i = ZERO; i < appointments.length; i += ONE) {
+        const { patient, ...appointment } = appointments[i];
         const lastNote = patient.notes.shift();
-        return {
+        appointments[i] = {
           ...appointment,
           patient: {
             ...patient,
             notes: lastNote ? [lastNote] : [],
           },
         };
-      });
+      }
 
       return appointments;
     } catch (err) {
@@ -207,18 +209,19 @@ export default class AppointmentService {
         'notes',
       ]);
 
-      let appointments: Appointment[] = await queryBuilder.getMany();
+      const appointments: Appointment[] = await queryBuilder.getMany();
 
-      appointments = appointments.map(({ patient, ...appointment }) => {
+      for (let i = ZERO; i < appointments.length; i += ONE) {
+        const { patient, ...appointment } = appointments[i];
         const lastNote = patient.notes.shift();
-        return {
+        appointments[i] = {
           ...appointment,
           patient: {
             ...patient,
             notes: lastNote ? [lastNote] : [],
           },
         };
-      });
+      }
 
       return appointments;
     } catch (err) {

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -328,6 +328,11 @@ export default class AppointmentService {
       const appointments = await this.appointmentRepository
         .createQueryBuilder('appointment')
         .leftJoinAndSelect('appointment.patient', 'patient')
+        .leftJoinAndSelect(
+          'patient.notes',
+          'notes',
+          'notes.createdAt = (SELECT MAX(n.createdAt) FROM note n WHERE n.patientId = patient.id)',
+        )
         .where(
           'appointment.localDoctorId = :id OR appointment.remoteDoctorId = :id',
           { id: doctor.id },

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -74,17 +74,33 @@ export default class AppointmentService {
         'remoteDoctor',
       );
       queryBuilder.leftJoinAndSelect('appointment.patient', 'patient');
+      queryBuilder.leftJoinAndSelect('patient.notes', 'notes');
       queryBuilder.select([
-        'appointment.id',
-        'appointment.startTime',
-        'appointment.endTime',
-        'appointment.zoomLink',
+        'appointment',
         'localDoctor.id',
+        'localDoctor.firstName',
+        'localDoctor.lastName',
         'remoteDoctor.id',
-        'patient.id',
+        'remoteDoctor.firstName',
+        'remoteDoctor.lastName',
+        'patient',
+        'notes',
       ]);
 
-      return await queryBuilder.getMany();
+      let appointments: Appointment[] = await queryBuilder.getMany();
+
+      appointments = appointments.map(({ patient, ...appointment }) => {
+        const lastNote = patient.notes.shift();
+        return {
+          ...appointment,
+          patient: {
+            ...patient,
+            notes: lastNote ? [lastNote] : [],
+          },
+        };
+      });
+
+      return appointments;
     } catch (err) {
       throw new HttpException(`${err}`, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -178,17 +194,33 @@ export default class AppointmentService {
         'remoteDoctor',
       );
       queryBuilder.leftJoinAndSelect('appointment.patient', 'patient');
+      queryBuilder.leftJoinAndSelect('patient.notes', 'notes');
       queryBuilder.select([
-        'appointment.id',
-        'appointment.startTime',
-        'appointment.endTime',
-        'appointment.zoomLink',
+        'appointment',
         'localDoctor.id',
+        'localDoctor.firstName',
+        'localDoctor.lastName',
         'remoteDoctor.id',
-        'patient.id',
+        'remoteDoctor.firstName',
+        'remoteDoctor.lastName',
+        'patient',
+        'notes',
       ]);
 
-      return await queryBuilder.getMany();
+      let appointments: Appointment[] = await queryBuilder.getMany();
+
+      appointments = appointments.map(({ patient, ...appointment }) => {
+        const lastNote = patient.notes.shift();
+        return {
+          ...appointment,
+          patient: {
+            ...patient,
+            notes: lastNote ? [lastNote] : [],
+          },
+        };
+      });
+
+      return appointments;
     } catch (err) {
       throw new HttpException(`${err}`, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -103,7 +103,7 @@ export default class AppointmentService {
     id: number,
     limit = TEN,
     all = false,
-  ): Promise<Appointment[]> {
+  ): Promise<{ appointments: Appointment[]; count: number }> {
     try {
       const doctor = await this.doctorService.getDoctorByID(id);
       const today = new Date();
@@ -146,9 +146,9 @@ export default class AppointmentService {
         queryBuilder.limit(limit);
       }
 
-      const appointments: Appointment[] = await queryBuilder.getMany();
+      const [appointments, count] = await queryBuilder.getManyAndCount();
 
-      return appointments;
+      return { appointments, count };
     } catch (err) {
       throw new HttpException(`${err}`, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/modules/availability/availability.service.ts
+++ b/src/modules/availability/availability.service.ts
@@ -91,6 +91,10 @@ export default class AvailabilityService {
           'doctor.id',
           'doctor.specialization',
           'doctor.role',
+          'doctor.firstName',
+          'doctor.lastName',
+          'doctor.country',
+          'doctor.city',
         ])
         .innerJoin('availability.doctor', 'doctor')
         .andWhere(

--- a/src/modules/patient/entity/patient.entity.ts
+++ b/src/modules/patient/entity/patient.entity.ts
@@ -8,7 +8,7 @@ export default class Patient {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @OneToMany(() => Note, (note) => note.doctor)
+  @OneToMany(() => Note, (note) => note.patient)
   notes: Note[];
 
   @ApiProperty({ example: 'John' })

--- a/src/modules/patient/patient.service.ts
+++ b/src/modules/patient/patient.service.ts
@@ -15,6 +15,11 @@ export default class PatientService {
     try {
       return await this.patientRepository
         .createQueryBuilder('patient')
+        .leftJoinAndSelect(
+          'patient.notes',
+          'notes',
+          'notes.createdAt = (SELECT MAX(n.createdAt) FROM note n WHERE n.patientId = patient.id)',
+        )
         .getMany();
     } catch (err) {
       throw new HttpException(`${err}`, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/modules/patient/patient.service.ts
+++ b/src/modules/patient/patient.service.ts
@@ -59,9 +59,17 @@ export default class PatientService {
 
   async getPatientById(patientId: number): Promise<Patient> {
     try {
-      return await this.patientRepository.findOneOrFail({
-        where: { id: patientId },
-      });
+      const queryResult = await this.patientRepository
+        .createQueryBuilder('patient')
+        .leftJoinAndSelect(
+          'patient.notes',
+          'note',
+          'note.createdAt = (SELECT MAX(n.createdAt) FROM note n WHERE n.patientId = patient.id)',
+        )
+        .where('patient.id = :patientId', { patientId })
+        .getOneOrFail();
+
+      return queryResult;
     } catch (err) {
       throw new HttpException(`${err}`, HttpStatus.INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
**Description changes:** 
- Add last note and local/remote fullnames in response

[link to Jira ticket 129](https://smartdc23.atlassian.net/browse/SMAR-129?atlOrigin=eyJpIjoiNDRkYjI1NzY4YjBlNDE4NGExMDQ3NDE4ZjZlNzA0MmUiLCJwIjoiaiJ9)
[link to Jira ticket 131](https://smartdc23.atlassian.net/browse/SMAR-131?atlOrigin=eyJpIjoiMGU3NTYwYjI0ODExNGY3NmEwNGIzN2QwNDdkMDM3YzIiLCJwIjoiaiJ9)

**PR checklist:**
1.1 Common
1.1.1 types for input and output params
1.1.2 no any, should be also added to eslint rules
1.1.3 try/catch for any async function
1.1.4 no magic numbers
1.1.5 compare only with constants not with strings
(instead of user === ‘admin’, better user === roles.admin)
1.1.6 no ternary operator inside ternary operator (bad example: question ? first:
second ? third: fourth)
1.1.7 avoid similar types with duplicating by generics
1.1.8 no console.log in pr
1.1.9 .env file should be in .gitignore
1.1.10 delete commented code if it's not part of documentation
1.1.11 no links in the code, env links should be in env file (for example: server url),
constant links (for example default avatar URL) should be in constant file
1.1.12 constants and function names should be lowercase.
1.1.13 no dates format in the code (like "dd/MM/yyyy”), move it in global constant
variable
1.1.14 import rules. imports should come in a specific order: node modules, absolute
path, relative path
1.1.15 strings should be in the constant variable. Example: instead of ‘15 3 * * *’,
const EACH_DAY_15h_15min = ‘15 3 * * *’

1.2 Backend
1.2.1 swagger for each endpoint
1.2.2 less requests to db, all data should be taken with one query
1.2.3 `public` in method use only is use function externally
1.2.4 use ConfigService instead of `process.env`

Example list of today fixed appointments:
![image](https://github.com/ZenBit-Tech/WebWizards_be/assets/72575014/ca737e43-fad3-4b44-83a5-8c0bbdb85d4b)
