### PR TITLE
fix: typo in uuid

### DIFF
--- a/src/modules/availability/entity/availability.entity.ts
+++ b/src/modules/availability/entity/availability.entity.ts
@@ -7,7 +7,7 @@ import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 export default class Availability {
   @PrimaryGeneratedColumn('uuid')
   @ApiProperty({ example: 'c3864420-2d55-4483-b861-4970e3b7ea40' })
-  uiid: string;
+  uuid: string;
 
   @Column()
   @ApiProperty({ example: 'Working hours' })


### PR DESCRIPTION
"uiid" typo - replace with "uuid"